### PR TITLE
Fix copy button duplication

### DIFF
--- a/resources/esoitemlink.js
+++ b/resources/esoitemlink.js
@@ -614,8 +614,11 @@ function AddEsoItemLinkCopyButton(id)
 	var element = $("#" + id);
 	var html = element.html();
 	var buttonHtml = "";
-	
-	buttonHtml = "<button class='esoil_copy_button' onclick='OnEsoItemLinkCopyClicked(this);'>Copy</button>";
+
+	// Add copy button if it does not already exist
+	if (element.find(".esoil_copy_button").length === 0) {
+		buttonHtml = "<button class='esoil_copy_button' onclick='OnEsoItemLinkCopyClicked(this);'>Copy</button>";
+	}
 	
 	element.html(html + buttonHtml);
 }


### PR DESCRIPTION
Quick workaround to skip duplication if buton already exists (see #5 ).

Just a suggestion.

AddEsoItemLinkCopyButton gets called a lot, resulting in some events duplicating the copy button. This does not fix the events, just the duplication.